### PR TITLE
Refactor parsers and change constructors for transaction class

### DIFF
--- a/src/main/java/duke/Data/duke.txt
+++ b/src/main/java/duke/Data/duke.txt
@@ -24,11 +24,12 @@ L|0|fries|date|13/10/2019|calorie|200
 B|1|burger|date|21/10/2019|sodium|100|fats|100|calorie|200
 L|1|curry|date|21/10/2019|calorie|200
 D|1|laksa|date|21/10/2019|calorie|300
+L|0|mala|date|27/10/2019|calorie|2000
 B|0|burger|date|17/10/2019|sodium|100|fats|100|calorie|100
 B|0|burger|date|17/10/2019|sodium|100|fats|100|calorie|100
+B|1|burger|date|26/10/2019|sodium|100|fats|100|calorie|100
 B|0|burger|date|26/10/2019|sodium|100|fats|100|calorie|100
-B|0|burger|date|26/10/2019|sodium|100|fats|100|calorie|100
-B|0|burger|date|14/10/2019|sodium|100|fats|100|calorie|100
-B|0|burger|date|14/10/2019|sodium|100|fats|100|calorie|100
 B|0|burger|date|20/10/2019|sodium|100|fats|100|calorie|100
 B|0|burger|date|20/10/2019|sodium|100|fats|100|calorie|100
+B|0|burger|date|14/10/2019|sodium|100|fats|100|calorie|100
+B|0|burger|date|14/10/2019|sodium|100|fats|100|calorie|100

--- a/src/main/java/duke/logic/commands/FindCommand.java
+++ b/src/main/java/duke/logic/commands/FindCommand.java
@@ -27,8 +27,10 @@ public class FindCommand extends Command {
     }
 
     public FindCommand(String description, String date) {
-        this.description = description;
-        this.currentDate = date;
+        this(description);
+        if (!date.isBlank()) {
+            this.currentDate = date;
+        }
     }
 
     /**

--- a/src/main/java/duke/logic/commands/ListCommand.java
+++ b/src/main/java/duke/logic/commands/ListCommand.java
@@ -32,13 +32,16 @@ public class ListCommand extends Command {
      * @throws DukeException if the date cannot be parsed
      */
     public ListCommand(String date) throws DukeException {
-        Date temp;
-        try {
-            temp = dateFormat.parse(date);
-        } catch (ParseException e) {
-            throw new DukeException(e.getMessage());
+        if (!date.isBlank()) {
+            Date temp;
+            try {
+                temp = dateFormat.parse(date);
+            } catch (ParseException e) {
+                throw new DukeException(e.getMessage());
+            }
+            currentDate = dateFormat.format(temp);
         }
-        currentDate = dateFormat.format(temp);
+
     }
 
     /**

--- a/src/main/java/duke/logic/commands/MarkDoneCommand.java
+++ b/src/main/java/duke/logic/commands/MarkDoneCommand.java
@@ -20,8 +20,6 @@ import duke.model.user.User;
  */
 public class MarkDoneCommand extends Command {
     private int index;
-    private final String helpText = "Please follow: done <index> /date <date> or "
-            + "done <index> to mark done the indexed meal for current day.";
 
     /**
      * Constructor for MarkDoneCommand.
@@ -30,13 +28,15 @@ public class MarkDoneCommand extends Command {
      */
     public MarkDoneCommand(String indexStr, String date) throws DukeException {
         this(indexStr);
-        Date parsedDate;
-        try {
-            parsedDate = dateFormat.parse(date);
-        } catch (ParseException e) {
-            throw new DukeException("Unable to parse input" + date + " as a date. " + helpText);
+        if (!date.isBlank()) {
+            Date parsedDate;
+            try {
+                parsedDate = dateFormat.parse(date);
+            } catch (ParseException e) {
+                throw new DukeException("Unable to parse input" + date + " as a date.");
+            }
+            this.currentDate = dateFormat.format(parsedDate);
         }
-        this.currentDate = dateFormat.format(parsedDate);
     }
 
     /**
@@ -48,7 +48,7 @@ public class MarkDoneCommand extends Command {
         try {
             this.index = Integer.parseInt(indexStr.trim());
         } catch (NumberFormatException e) {
-            throw new DukeException("Unable to parse input " + indexStr + " as integer index. " + helpText);
+            throw new DukeException("Unable to parse input " + indexStr + " as integer index.");
         }
     }
 

--- a/src/main/java/duke/logic/parsers/AddBreakfastCommandParser.java
+++ b/src/main/java/duke/logic/parsers/AddBreakfastCommandParser.java
@@ -17,16 +17,9 @@ public class AddBreakfastCommandParser implements ParserInterface<AddCommand> {
      */
     @Override
     public AddCommand parse(String userInput) throws DukeException {
-        if (userInput.trim().length() == 0) {
-            throw new DukeException("\u2639 OOPS!!! The description of the command cannot be empty.");
-        }
-        if (userInput.contains("/")) {
-            String mealName = userInput.split("/", 2)[0].trim();
-            String mealInfo = "/" + userInput.split("/", 2)[1];
-            return new AddCommand(new Breakfast(mealName, mealInfo));
-        } else {
-            //todo: handle trailing userInput without "/"
-            return new AddCommand(new Breakfast(userInput, ""));
-        }
+        InputValidator.validate(userInput);
+        String[] mealNameAndInfo = ArgumentSplitter.splitMealArguments(userInput);
+        return new AddCommand(new Breakfast(mealNameAndInfo[0], mealNameAndInfo[1]));
+        //todo: handle trailing userInput without "/"
     }
 }

--- a/src/main/java/duke/logic/parsers/AddDinnerCommandParser.java
+++ b/src/main/java/duke/logic/parsers/AddDinnerCommandParser.java
@@ -17,16 +17,9 @@ public class AddDinnerCommandParser implements ParserInterface<AddCommand> {
      */
     @Override
     public AddCommand parse(String userInput) throws DukeException {
-        if (userInput.trim().length() == 0) {
-            throw new DukeException("\u2639 OOPS!!! The description of the command cannot be empty.");
-        }
-        if (userInput.contains("/")) {
-            String mealName = userInput.split("/", 2)[0].trim();
-            String mealInfo = "/" + userInput.split("/", 2)[1];
-            return new AddCommand(new Dinner(mealName, mealInfo));
-        } else {
-            //todo: handle trailing userInput without "/"
-            return new AddCommand(new Dinner(userInput, ""));
-        }
+        InputValidator.validate(userInput);
+        String[] mealNameAndInfo = ArgumentSplitter.splitMealArguments(userInput);
+        return new AddCommand(new Dinner(mealNameAndInfo[0], mealNameAndInfo[1]));
+        //todo: handle trailing userInput without "/"
     }
 }

--- a/src/main/java/duke/logic/parsers/AddItemCommandParser.java
+++ b/src/main/java/duke/logic/parsers/AddItemCommandParser.java
@@ -16,8 +16,8 @@ public class AddItemCommandParser implements ParserInterface<AddItemCommand> {
      * @throws DukeException when the user input cannot be parsed
      */
     public AddItemCommand parse(String userInput) throws DukeException {
-        String name = userInput.split("/", 2)[0].trim();
-        String info = "/" + userInput.split("/", 2)[1];
-        return new AddItemCommand(new Item(name, info));
+        InputValidator.validate(userInput);
+        String[] mealNameAndInfo = ArgumentSplitter.splitMealArguments(userInput);
+        return new AddItemCommand(new Item(mealNameAndInfo[0], mealNameAndInfo[1]));
     }
 }

--- a/src/main/java/duke/logic/parsers/AddLunchCommandParser.java
+++ b/src/main/java/duke/logic/parsers/AddLunchCommandParser.java
@@ -17,16 +17,8 @@ public class AddLunchCommandParser implements ParserInterface<AddCommand> {
      */
     @Override
     public AddCommand parse(String userInput) throws DukeException {
-        if (userInput.trim().length() == 0) {
-            throw new DukeException("\u2639 OOPS!!! The description of the command cannot be empty.");
-        }
-        if (userInput.contains("/")) {
-            String mealName = userInput.split("/", 2)[0].trim();
-            String mealInfo = "/" + userInput.split("/", 2)[1];
-            return new AddCommand(new Lunch(mealName, mealInfo));
-        } else {
-            //todo: handle trailing userInput without "/"
-            return new AddCommand(new Lunch(userInput, ""));
-        }
+        InputValidator.validate(userInput);
+        String[] mealNameAndInfo = ArgumentSplitter.splitMealArguments(userInput);
+        return new AddCommand(new Lunch(mealNameAndInfo[0], mealNameAndInfo[1]));
     }
 }

--- a/src/main/java/duke/logic/parsers/ArgumentSplitter.java
+++ b/src/main/java/duke/logic/parsers/ArgumentSplitter.java
@@ -1,0 +1,25 @@
+package duke.logic.parsers;
+
+public class ArgumentSplitter {
+
+    public static String[] splitMealArguments(String userInput) {
+
+        String[] splitStrings = userInput.split("/", 2);
+        String mealName = splitStrings[0].trim();
+        String mealInfo = "";
+        if (splitStrings.length > 1) {
+            mealInfo += "/";
+            mealInfo += splitStrings[1];
+        }
+        return new String[]{mealName, mealInfo};
+    }
+
+    public static String[] splitArguments(String userInput, String delimiter) {
+        String[] splitStrings = userInput.split(delimiter, 2);
+        splitStrings[0] = splitStrings[0].trim();
+        if (splitStrings.length < 2) {
+            return new String[] {splitStrings[0], ""};
+        }
+        return new String[] {splitStrings[0], splitStrings[1]};
+    }
+}

--- a/src/main/java/duke/logic/parsers/ClearCommandParser.java
+++ b/src/main/java/duke/logic/parsers/ClearCommandParser.java
@@ -16,15 +16,8 @@ public class ClearCommandParser implements ParserInterface<ClearCommand> {
      */
     @Override
     public ClearCommand parse(String userInput) throws DukeException {
-        if (userInput.trim().length() != 0) {
-            String[] splitArgs = userInput.split(" ", 2);
-            if (splitArgs.length >= 2) {
-                return new ClearCommand(splitArgs[0], splitArgs[1]);
-            } else {
-                throw new DukeException("Please enter 2 dates; Start and End dates to clear meals from.");
-            }
-        } else {
-            throw new DukeException("Please enter 2 dates; Start and End dates to clear meals from.");
-        }
+        InputValidator.validate(userInput);
+        String[] startAndEndDates = ArgumentSplitter.splitArguments(userInput, " ");
+        return new ClearCommand(startAndEndDates[0], startAndEndDates[1]);
     }
 }

--- a/src/main/java/duke/logic/parsers/DeleteCommandParser.java
+++ b/src/main/java/duke/logic/parsers/DeleteCommandParser.java
@@ -16,18 +16,8 @@ public class DeleteCommandParser implements ParserInterface<DeleteCommand> {
      */
     @Override
     public DeleteCommand parse(String userInput) throws DukeException {
-        if (userInput.trim().length() != 0) {
-            // user specifies date and index.
-            if (userInput.split("/date").length >= 2) {
-                String[] splitArgs = userInput.split("/date", 2);
-                return new DeleteCommand(splitArgs[0], splitArgs[1]);
-            } else {
-                // user only specifies index to delete for current day.
-                return new DeleteCommand(userInput);
-            }
-        } else {
-            throw new DukeException("Please enter index of meal to delete on today's list or "
-                    + "date and index of meal to delete");
-        }
+        InputValidator.validate(userInput);
+        String[] indexAndDate = ArgumentSplitter.splitArguments(userInput, "/date");
+        return new DeleteCommand(indexAndDate[0], indexAndDate[1]);
     }
 }

--- a/src/main/java/duke/logic/parsers/DepositCommandParser.java
+++ b/src/main/java/duke/logic/parsers/DepositCommandParser.java
@@ -21,25 +21,8 @@ public class DepositCommandParser implements ParserInterface<AddTransactionComma
      */
     @Override
     public AddTransactionCommand parse(String userInput) throws DukeException {
-        if (userInput.trim().length() == 0) {
-            throw new DukeException("Please enter the amount to deposit for today's date or date"
-                    + " and amount to be deposited");
-        }
-        if (userInput.contains("/date")) {
-            String depositAmountString = userInput.split("/date", 2)[0].trim();
-            BigDecimal depositAmount = new BigDecimal(depositAmountString);
-            String dateString = userInput.split("/date", 2)[1].trim();
-            Date parsedDate;
-            try {
-                parsedDate = dateFormat.parse(dateString);
-            } catch (ParseException e) {
-                throw new DukeException("Unable to parse input" + dateString + "as a date.");
-            }
-            dateString = dateFormat.format(parsedDate);
-            return new AddTransactionCommand(new Deposit(depositAmount, dateString));
-        } else {
-            BigDecimal depositAmount = new BigDecimal(userInput);
-            return new AddTransactionCommand(new Deposit(depositAmount));
-        }
+        InputValidator.validate(userInput);
+        String[] amountAndDate = ArgumentSplitter.splitArguments(userInput, "/date");
+        return new AddTransactionCommand(new Deposit(amountAndDate[0], amountAndDate[1]));
     }
 }

--- a/src/main/java/duke/logic/parsers/DoneCommandParser.java
+++ b/src/main/java/duke/logic/parsers/DoneCommandParser.java
@@ -16,16 +16,8 @@ public class DoneCommandParser implements ParserInterface<MarkDoneCommand> {
      */
     @Override
     public MarkDoneCommand parse(String userInput) throws DukeException {
-        if (userInput.trim().length() != 0) {
-            if (userInput.split("/date").length >= 2) {
-                String[] splitArgs = userInput.split("/date", 2);
-                return new MarkDoneCommand(splitArgs[0], splitArgs[1]);
-            } else {
-                return new MarkDoneCommand(userInput);
-            }
-        } else {
-            throw new DukeException("Please enter index of meal to be marked done on today's list or "
-                    + "date and index of meal to be marked done");
-        }
+        InputValidator.validate(userInput);
+        String[] indexAndDate = ArgumentSplitter.splitArguments(userInput, "/date");
+        return new MarkDoneCommand(indexAndDate[0], indexAndDate[1]);
     }
 }

--- a/src/main/java/duke/logic/parsers/EditCommandParser.java
+++ b/src/main/java/duke/logic/parsers/EditCommandParser.java
@@ -17,8 +17,8 @@ public class EditCommandParser implements ParserInterface<EditCommand> {
      */
     @Override
     public EditCommand parse(String userInput) throws DukeException {
-        String name = userInput.split("/", 2)[0];
-        String info = "/" + userInput.split("/", 2)[1];
-        return new EditCommand(new Meal(name, info));
+        InputValidator.validate(userInput);
+        String[] mealNameAndInfo = ArgumentSplitter.splitMealArguments(userInput);
+        return new EditCommand(new Meal(mealNameAndInfo[0], mealNameAndInfo[1]));
     }
 }

--- a/src/main/java/duke/logic/parsers/FindCommandParser.java
+++ b/src/main/java/duke/logic/parsers/FindCommandParser.java
@@ -16,12 +16,8 @@ public class FindCommandParser implements ParserInterface<FindCommand> {
      */
     @Override
     public FindCommand parse(String userInput) throws DukeException {
-        String name = userInput.split(" /date ", 2)[0];
-        if (userInput.split(" /date ").length > 1) {
-            String date = userInput.split(" /date ")[1];
-            return new FindCommand(name, date);
-        } else {
-            return new FindCommand(name);
-        }
+        InputValidator.validate(userInput);
+        String[] nameAndDate = ArgumentSplitter.splitArguments(userInput, " /date ");
+        return new FindCommand(nameAndDate[0], nameAndDate[1]);
     }
 }

--- a/src/main/java/duke/logic/parsers/HelpCommandParser.java
+++ b/src/main/java/duke/logic/parsers/HelpCommandParser.java
@@ -16,9 +16,6 @@ public class HelpCommandParser implements ParserInterface<HelpCommand> {
      */
     @Override
     public HelpCommand parse(String userInput) throws DukeException {
-        if (userInput.trim().length() >= 0) {
-            return new HelpCommand(userInput);
-        }
-        return new HelpCommand();
+        return new HelpCommand(userInput);
     }
 }

--- a/src/main/java/duke/logic/parsers/InputValidator.java
+++ b/src/main/java/duke/logic/parsers/InputValidator.java
@@ -1,0 +1,13 @@
+package duke.logic.parsers;
+
+import duke.commons.exceptions.DukeException;
+
+public class InputValidator {
+
+    public static void validate(String userInput) throws DukeException {
+        if (userInput.trim().length() == 0) {
+            throw new DukeException("OOPS!!! The description of the command cannot be empty.");
+        }
+        //TODO: Throw exceptions for different commands
+    }
+}

--- a/src/main/java/duke/logic/parsers/ListCommandParser.java
+++ b/src/main/java/duke/logic/parsers/ListCommandParser.java
@@ -16,10 +16,6 @@ public class ListCommandParser implements ParserInterface<ListCommand> {
      */
     @Override
     public ListCommand parse(String userInput) throws DukeException {
-        if (userInput.trim().length() != 0) {
-            return new ListCommand(userInput);
-        } else {
-            return new ListCommand();
-        }
+        return new ListCommand(userInput);
     }
 }

--- a/src/main/java/duke/logic/parsers/PaymentCommandParser.java
+++ b/src/main/java/duke/logic/parsers/PaymentCommandParser.java
@@ -21,25 +21,8 @@ public class PaymentCommandParser implements ParserInterface<AddTransactionComma
      */
     @Override
     public AddTransactionCommand parse(String userInput) throws DukeException {
-        if (userInput.trim().length() == 0) {
-            throw new DukeException("Please enter the amount to be paid for today's date or"
-                    + "the date and the amount to be deposited");
-        }
-        if (userInput.contains("/date")) {
-            String paymentAmountString = userInput.split("/date", 2)[0].trim();
-            BigDecimal paymentAmount = new BigDecimal(paymentAmountString);
-            String dateString = userInput.split("/date", 2)[1].trim();
-            Date parsedDate;
-            try {
-                parsedDate = dateFormat.parse(dateString);
-            } catch (ParseException e) {
-                throw new DukeException("Unable to parse input" + dateString + "as a date.");
-            }
-            dateString = dateFormat.format(parsedDate);
-            return new AddTransactionCommand(new Payment(paymentAmount, dateString));
-        } else {
-            BigDecimal paymentAmount = new BigDecimal(userInput);
-            return new AddTransactionCommand(new Payment(paymentAmount));
-        }
+        InputValidator.validate(userInput);
+        String[] amountAndDate = ArgumentSplitter.splitArguments(userInput, "/date");
+        return new AddTransactionCommand(new Payment(amountAndDate[0], amountAndDate[1]));
     }
 }

--- a/src/main/java/duke/logic/parsers/SuggestCommandParser.java
+++ b/src/main/java/duke/logic/parsers/SuggestCommandParser.java
@@ -16,6 +16,7 @@ public class SuggestCommandParser implements ParserInterface<SuggestCommand> {
      */
     @Override
     public SuggestCommand parse(String userInput) throws DukeException {
+        InputValidator.validate(userInput);
         // TODO: Finalize suggest command input format and update UG/DG
         return new SuggestCommand();
     }

--- a/src/main/java/duke/model/Deposit.java
+++ b/src/main/java/duke/model/Deposit.java
@@ -3,13 +3,8 @@ package duke.model;
 import java.math.BigDecimal;
 
 public class Deposit extends Transaction {
-    public Deposit(BigDecimal transactionAmount, String dateString) {
-        super(transactionAmount, dateString);
-        super.type = "DEP";
-    }
-
-    public Deposit(BigDecimal transactionAmount) {
-        super(transactionAmount);
+    public Deposit(String amountString, String dateString) {
+        super(amountString, dateString);
         super.type = "DEP";
     }
 

--- a/src/main/java/duke/model/Payment.java
+++ b/src/main/java/duke/model/Payment.java
@@ -3,13 +3,8 @@ package duke.model;
 import java.math.BigDecimal;
 
 public class Payment extends Transaction {
-    public Payment(BigDecimal transactionAmount, String dateString) {
-        super(transactionAmount, dateString);
-        super.type = "PAY";
-    }
-
-    public Payment(BigDecimal transactionAmount) {
-        super(transactionAmount);
+    public Payment(String amountString, String dateString) {
+        super(amountString, dateString);
         super.type = "PAY";
     }
 

--- a/src/main/java/duke/model/Transaction.java
+++ b/src/main/java/duke/model/Transaction.java
@@ -10,13 +10,9 @@ public class Transaction {
     protected SimpleDateFormat dateParser = new SimpleDateFormat("dd/MM/yyyy");
     protected String date = dateParser.format(Calendar.getInstance().getTime());
 
-    public Transaction(BigDecimal transactionAmount, String dateString) {
-        this.transactionAmount = transactionAmount;
+    public Transaction(String amountString, String dateString) {
+        this.transactionAmount = new BigDecimal(amountString);
         this.date = dateString;
-    }
-
-    public Transaction(BigDecimal transactionAmount) {
-        this.transactionAmount = transactionAmount;
     }
 
     public String getType() {

--- a/src/main/java/duke/storage/LoadLineParser.java
+++ b/src/main/java/duke/storage/LoadLineParser.java
@@ -50,7 +50,7 @@ public class LoadLineParser {
     public static void parseTransactions(TransactionList transactionList, String line, User user) {
         String[] splitLine = line.split("\\|", 3);
         String transactionType = splitLine[0];
-        BigDecimal transactionAmount = new BigDecimal(splitLine[1]);
+        String transactionAmount = splitLine[1];
         String transactionDate = splitLine[2];
         Transaction newTransaction;
         if (transactionType.equals("PAY")) {


### PR DESCRIPTION
I refactored the `commandParsers` to include `inputValidator` (that validates whether the input is empty or not) and include a `argumentSplitter` (that splits the arguments). On top of that, the constructor `transactionAmount` (with type `BigDecimal`) for the transaction class has been changed to `amountString` (with type `String`). This is intended so that it will not clutter the parser and the conversion from `string` to `BigDecimal` only happens inside the class, which improves readability. 

Suggestion:
The validate and `argumentSplitter` could be put under the class `commandParsersUtil`